### PR TITLE
Fix: Handle YAML frontmatter in Markdown posts

### DIFF
--- a/app.js
+++ b/app.js
@@ -40,7 +40,23 @@ document.addEventListener('DOMContentLoaded', () => {
             if (!response.ok) {
                 throw new Error(`HTTP error! status: ${response.status} while fetching ${fileName}`);
             }
-            const markdownText = await response.text();
+            let markdownText = await response.text();
+
+            // Strip YAML frontmatter
+            const firstSeparator = markdownText.indexOf('---');
+            if (firstSeparator === 0 || (firstSeparator > 0 && markdownText[firstSeparator-1] === '\n')) {
+                const secondSeparator = markdownText.indexOf('---', firstSeparator + 3);
+                if (secondSeparator !== -1) {
+                    const afterSecondSeparator = markdownText.indexOf('\n', secondSeparator + 3);
+                    if (afterSecondSeparator !== -1) {
+                        markdownText = markdownText.substring(afterSecondSeparator + 1);
+                    } else {
+                        // Edge case: file ends right after the second '---'
+                        markdownText = '';
+                    }
+                }
+            }
+
             postContentDiv.innerHTML = renderMarkdown(markdownText);
         } catch (error) {
             console.error('Error fetching post:', error);


### PR DESCRIPTION
Previously, posts containing YAML frontmatter (e.g., `first_post.md`) would cause two issues:
1. A JavaScript error "Unexpected token '{'" because the Markdown parser attempted to parse the YAML.
2. A misleading "Error loading post: HTTP error! status: 404" message, likely a consequence of the parsing failure.

This commit updates `app.js` to strip YAML frontmatter (content between and including `---` lines at the beginning of the file) before passing the Markdown content to the `marked.js` parser.

This resolves both the syntax error and the loading error for `first_post.md`, allowing it to be displayed correctly. Other posts without frontmatter continue to load as expected.