### PR TITLE
Fix: Ensure Marked.js is loaded before rendering posts

### DIFF
--- a/app.js
+++ b/app.js
@@ -98,20 +98,35 @@ document.addEventListener('DOMContentLoaded', () => {
     // Initial setup
     loadPostList();
 
-    // Optional: Load a post based on URL hash or default to first post
-    if (window.location.hash) {
-        const postFromHash = window.location.hash.substring(1); // Remove #
-        if (posts.includes(postFromHash)) {
-            fetchAndDisplayPost(postFromHash);
+    function initializeDiary() {
+        // Optional: Load a post based on URL hash or default to first post
+        if (window.location.hash) {
+            const postFromHash = window.location.hash.substring(1); // Remove #
+            if (posts.includes(postFromHash)) {
+                fetchAndDisplayPost(postFromHash);
+            } else if (posts.length > 0) {
+                // Fallback to first post if hash is invalid
+                fetchAndDisplayPost(posts[0]);
+            } else {
+                 if (postContentDiv) postContentDiv.innerHTML = '<p>No posts found.</p>';
+            }
         } else if (posts.length > 0) {
-            // Fallback to first post if hash is invalid
-            fetchAndDisplayPost(posts[0]);
+            fetchAndDisplayPost(posts[0]); // Load the first post by default
         } else {
-             if (postContentDiv) postContentDiv.innerHTML = '<p>No posts found.</p>';
+            if (postContentDiv) postContentDiv.innerHTML = '<p>No posts found.</p>';
         }
-    } else if (posts.length > 0) {
-        fetchAndDisplayPost(posts[0]); // Load the first post by default
+    }
+
+    const markedScript = document.getElementById('marked-script');
+
+    if (typeof marked !== 'undefined') {
+        initializeDiary();
+    } else if (markedScript) {
+        markedScript.onload = initializeDiary;
     } else {
-        if (postContentDiv) postContentDiv.innerHTML = '<p>No posts found.</p>';
+        // Fallback if script tag not found, though this shouldn't happen with the ID in place
+        console.error('Marked script tag not found. Initial post loading might fail.');
+        // Try to initialize anyway, or provide a user message
+        initializeDiary();
     }
 });

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
             <p>Select a post to read.</p>
         </main>
     </div>
-    <script src="lib/marked.min.js"></script>
+    <script src="lib/marked.min.js" id="marked-script"></script>
     <script src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
The initial post rendering was attempted before Marked.js had fully loaded, leading to an error because the `marked` object was undefined.

This commit defers the initial call to `fetchAndDisplayPost` until Marked.js has loaded. This is achieved by:
1. Adding an ID to the `marked.min.js` script tag in `index.html`.
2. In `app.js`, creating an `initializeDiary` function that contains the initial post loading logic.
3. Calling `initializeDiary` only after confirming that the `marked` object is defined, either because it was already loaded or by using the `onload` event of the `marked.min.js` script tag.

This ensures that `marked.parse()` is only called after the library is available, resolving the "Marked.js library not loaded" error.